### PR TITLE
Support additional versions in exerciser

### DIFF
--- a/public/scripts/exerciser.js
+++ b/public/scripts/exerciser.js
@@ -11,6 +11,8 @@ var jsonataResult;
 var jsonataError;
 
 var jsonataVersions = {
+    '1.4.1': 'v1.4.1',
+    '1.4.0': 'v1.4.0',
     '1.3.3': 'v1.3.3',
     '1.3.2': 'v1.3.2',
     '1.3.1': 'v1.3.1',

--- a/public/scripts/exerciser.js
+++ b/public/scripts/exerciser.js
@@ -11,6 +11,7 @@ var jsonataResult;
 var jsonataError;
 
 var jsonataVersions = {
+    '1.5.0': 'v1.5.0',
     '1.4.1': 'v1.4.1',
     '1.4.0': 'v1.4.0',
     '1.3.3': 'v1.3.3',


### PR DESCRIPTION
Add support for `J: use 1.4.0`, `J: use 1.4.1` and `J: use 1.5.0` in the exerciser.