### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "morgan": "^1.9.0",
     "errorhandler": "^1.5.0",
     "codemirror": "^5.19.0",
-    "moment": "^2.15.1",
-    "jsonata": "^1.3.0",
+    "moment": "^2.20.1",
+    "jsonata": "^1.5.0",
     "shortid": "^2.2.8"
   },
   "devDependencies": {
-    "browserify": "^13.1.0"
+    "browserify": "^15.2.0"
   },
   "engines": {
   	"node": "6.x"


### PR DESCRIPTION
Updating dependencies; want to pick up `JSONata@1.5.0` as minimum so that latest `J:use` updates will work. More importantly there's a security issue on the minimum version of `moment` so this enforces a fixed version as minimum.