### PR TITLE
Update browserify and method-override to latest major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "shortid": "^2.2.8"
   },
   "devDependencies": {
-    "browserify": "^15.2.0"
+    "browserify": "^16.2.2"
   },
   "engines": {
   	"node": "6.x"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ejs": "^2.5.7",
     "cloudant": "^1.10.0",
     "body-parser": "^1.18.2",
-    "method-override": "^2.3.10",
+    "method-override": "^3.0.0",
     "morgan": "^1.9.0",
     "errorhandler": "^1.5.0",
     "codemirror": "^5.19.0",


### PR DESCRIPTION
Adopt v16 of `browserify` to keep dependencies up to date.