### PR TITLE
Add the Posts example to illustrate a use for $lookup

### DIFF
--- a/src/Exerciser.js
+++ b/src/Exerciser.js
@@ -466,6 +466,7 @@ class Exerciser extends React.Component {
                         <option value="Address">Address</option>
                         <option value="Schema">Schema</option>
                         <option value="Library">Library</option>
+                        <option value="Posts">Posts</option>
                     </select>
                 </div>
                 <SplitPane split="horizontal" minSize={50} defaultSize={170}>

--- a/src/sample.js
+++ b/src/sample.js
@@ -365,5 +365,78 @@ export default {
   'book': $B.title,
   'due': $L.return
 }`
+    },
+    Posts: {
+        json: {
+            posts : {
+                byId : {
+                    "post1" : {
+                        id : "post1",
+                        author : "user1",
+                        body : "... user 1 ...",
+                        comments : ["comment1", "comment2"]
+                    },
+                    "post2" : {
+                        id : "post2",
+                        author : "user2",
+                        body : "... user 2 ...",
+                        comments : ["comment3", "comment4", "comment5"]
+                    }
+                },
+                allIds : ["post1", "post2"]
+            },
+            comments : {
+                byId : {
+                    "comment1" : {
+                        id : "comment1",
+                        author : "user2",
+                        comment : "... comment 1 ...",
+                    },
+                    "comment2" : {
+                        id : "comment2",
+                        author : "user3",
+                        comment : "... comment 2 ...",
+                    },
+                    "comment3" : {
+                        id : "comment3",
+                        author : "user3",
+                        comment : "... comment 3 ...",
+                    },
+                    "comment4" : {
+                        id : "comment4",
+                        author : "user1",
+                        comment : "... comment 4 ...",
+                    },
+                    "comment5" : {
+                        id : "comment5",
+                        author : "user3",
+                        comment : "... comment 5 ...",
+                    },
+                },
+                allIds : ["comment1", "comment2", "comment3", "commment4", "comment5"]
+            },
+            users : {
+                byId : {
+                    "user1" : {
+                        username : "user1",
+                        name : "User 1",
+                    },
+                    "user2" : {
+                        username : "user2",
+                        name : "User 2",
+                    },
+                    "user3" : {
+                        username : "user3",
+                        name : "User 3",
+                    }
+                },
+                allIds : ["user1", "user2", "user3"]
+            }
+        },
+        jsonata: `(
+    $comment := function($cid) {( comments.byId.$lookup($cid) )};
+    $post := function($pid) {( posts.byId.$lookup($pid) )};
+    posts.allIds{$: $post($).comments.$comment($)}
+)`
     }
 }


### PR DESCRIPTION
This adds an example based on the recommendations for a redux state shape:

- https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape/

I have added this because I believe that a good example of `$lookup` should be beneficial.
The added query is:

```js
(
    $comment := function($cid) {( comments.byId.$lookup($cid) )};
    $post := function($pid) {( posts.byId.$lookup($pid) )};
    posts.allIds{$: $post($).comments.$comment($)}
)
```
