### PR TITLE
Migrate serverless functions off CF namespace

### DIFF
--- a/serverless/prepare-insert/package.json
+++ b/serverless/prepare-insert/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "predeploy": "ibmcloud fn package update jsonata --param CAPTCHA_SECRET $CAPTCHA_SECRET",
-    "deploy": "ibmcloud fn action update jsonata/prepare-insert dist/bundle.js --kind nodejs:10 --web true"
+    "deploy": "ibmcloud fn action update /_/prepare-insert dist/bundle.js --kind nodejs:20"
   },
   "dependencies": {
     "querystring": "^0.2.0",

--- a/serverless/prepare-insert/prepare-insert.js
+++ b/serverless/prepare-insert/prepare-insert.js
@@ -53,7 +53,7 @@ function main(params) {
                     if (params.error) {
                         doc.error = params.error;
                     }
-                    return resolve({doc: doc});
+                    return resolve({ dbname: 'exerciser', doc: doc });
                 } else {
                     // failed the reCaptcha challenge
                     return reject({ statusCode: 400, msg: 'Failed the robot challenge!' });

--- a/serverless/set-docid.js
+++ b/serverless/set-docid.js
@@ -8,5 +8,5 @@
   *
   */
 function main(params) {
-	return { docid: params.id };
+	return { dbname: 'exerciser', docid: params.id };
 }

--- a/serverless/slack-invite/package.json
+++ b/serverless/slack-invite/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "predeploy": "ibmcloud fn package update jsonata --param SLACK_TOKEN $SLACK_TOKEN",
-    "deploy": "ibmcloud fn action update jsonata/slack-invite dist/bundle.js --kind nodejs:10 --web true"
+    "deploy": "ibmcloud fn action update /_/slack-invite dist/bundle.js --kind nodejs:20 --web true"
   },
   "dependencies": {
     "querystring": "^0.2.0",

--- a/src/Exerciser.js
+++ b/src/Exerciser.js
@@ -24,7 +24,7 @@ import ExternalLibsComponent, { getLibraryHandle } from './externalLibsComponent
 Modal.setAppElement('#root');
 
 const recaptchaRef = React.createRef();
-const baseUri = 'https://c40c296d.us-south.apigw.appdomain.cloud/api/';
+const baseUri = 'https://us-south.functions.appdomain.cloud/api/v1/web/04d6b400-5947-46c6-ae3e-ebdf4a7056de/default/';
 
 const customStyles = {
     content: {
@@ -97,7 +97,7 @@ class Exerciser extends React.Component {
 
     componentDidMount() {
         this.loadJSONata();
-        fetch(baseUri + 'versions')
+        fetch(baseUri + 'jsonata-versions.json')
             .then(res => res.json())
             .then(
                 result => {
@@ -124,7 +124,7 @@ class Exerciser extends React.Component {
             this.setState({ json: 'Loading...', jsonata: 'Loading...' });
             const self = this;
             // load the data
-            fetch(baseUri + 'shared?id=' + this.props.data)
+            fetch(baseUri + 'get-shared.json?id=' + this.props.data)
                 .then(res => res.json())
                 .then(result =>{
                     return Promise.all([Promise.resolve(result), this.getExternalLibsInitialized(result.externalLibs)])
@@ -497,7 +497,7 @@ class Exerciser extends React.Component {
             recaptcha: resp
         };
 
-        const url = baseUri + 'slack';
+        const url = baseUri + 'slack-invite';
         fetch(url, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
CloudFoundry is being removed from IBM cloud.
I needed to migrate the serverless functions to a different resource group so they don’t get deleted.