### PR TITLE
Lazy string matching

### DIFF
--- a/src/jsonataMode.js
+++ b/src/jsonataMode.js
@@ -13,8 +13,8 @@ function registerJsonata(monaco) {
         tokenizer: {
             root: [
                 [/\/\*.*\*\//, "jsonata-comment"],
-                [/'.*'/, "jsonata-string"],
-                [/".*"/, "jsonata-string"],
+                [/'.*?'/, "jsonata-string"],
+                [/".*?"/, "jsonata-string"],
                 [/\$[a-zA-Z0-9_]*/, "jsonata-variable"],
                 [/[a-zA-Z0-9_]+/, "jsonata-names"],
             ]


### PR DESCRIPTION
The JSONata monaco tokenizer greedily matches quotes, and so when multiple string appear on the same line it tokenises incorrectly and syntax highlights the whole line as a string:
<img width="933" alt="Screenshot 2024-01-31 at 16 11 48" src="https://github.com/jsonata-js/jsonata-exerciser/assets/3779290/18b38370-1e43-40be-beca-a2662408da62">

Making the regexes lazy solves the problem:
<img width="933" alt="Screenshot 2024-01-31 at 16 14 02" src="https://github.com/jsonata-js/jsonata-exerciser/assets/3779290/4567a516-5631-4e1f-9339-a7421c3a7b18">
